### PR TITLE
シフト作成のためのボタンコンポーネントを作成

### DIFF
--- a/cocofill-client/src/app/components/ShiftButton.tsx
+++ b/cocofill-client/src/app/components/ShiftButton.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Fade from "@mui/material/Fade";
+import CircleIcon from "@mui/icons-material/Circle";
+
+interface FadeMenuProps {
+  id: string; // ボタンごとの一意のIDを設定する
+}
+
+export default function FadeMenu({ id }: FadeMenuProps) {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [selectedValue, setSelectedValue] = React.useState(
+    () => localStorage.getItem(`selectedValue-${id}`) || "＋" // 各ボタンに固有のキーを使用？？
+  );
+
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleMenuItemClick = (value: string) => {
+    setSelectedValue(value); // 選択された値を状態に設定
+    localStorage.setItem(`selectedValue-${id}`, value); // 各ボタンに固有のキーでローカルストレージに保存
+    handleClose(); // メニューを閉じる
+  };
+
+  // ボタンの背景色を選択値に応じて設定
+  const getButtonColor = () => {
+    switch (selectedValue) {
+      case "朝":
+        return "#FC9CB6"; // ピンク
+      case "中":
+        return "#F7B532"; // オレンジ
+      case "遅":
+        return "#AD90ED"; // 紫
+      case "休":
+        return "#CBC9C9"; // 灰色
+      default:
+        return "transparent"; // デフォルトの色(未選択時)
+    }
+  };
+
+  return (
+    <>
+      <Button
+        id={`fade-button-${id}`}
+        variant="outlined"
+        aria-controls={open ? `fade-menu-${id}` : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        sx={{
+          backgroundColor: getButtonColor(),
+          color: selectedValue !== "＋" ? "#FFFFFF" : undefined,
+          borderColor: selectedValue === "＋" ? undefined : "transparent", // 選択時はボーダーを消す
+          "&:hover": {
+            backgroundColor: getButtonColor(),
+            opacity: 0.8,
+          },
+        }}
+      >
+        {selectedValue} {/* 選択された値を表示 */}
+      </Button>
+      <Menu
+        id={`fade-menu-${id}`}
+        MenuListProps={{
+          "aria-labelledby": `fade-button-${id}`,
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        TransitionComponent={Fade}
+      >
+        <MenuItem
+          onClick={() => handleMenuItemClick("朝")}
+          sx={{ color: "#4B4B4B" }}
+        >
+          <CircleIcon fontSize="small" sx={{ pr: 1, color: "#F89DB5" }} />朝
+        </MenuItem>
+        <MenuItem
+          onClick={() => handleMenuItemClick("中")}
+          sx={{ color: "#4B4B4B" }}
+        >
+          <CircleIcon fontSize="small" sx={{ pr: 1, color: "#FCC049" }} />中
+        </MenuItem>
+        <MenuItem
+          onClick={() => handleMenuItemClick("遅")}
+          sx={{ color: "#4B4B4B" }}
+        >
+          <CircleIcon fontSize="small" sx={{ pr: 1, color: "#D786EC" }} />遅
+        </MenuItem>
+        <MenuItem
+          onClick={() => handleMenuItemClick("休")}
+          sx={{ color: "#4B4B4B" }}
+        >
+          <CircleIcon fontSize="small" sx={{ pr: 1, color: "#CBC9C9" }} />休
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/cocofill-client/src/app/components/ShiftButton.tsx
+++ b/cocofill-client/src/app/components/ShiftButton.tsx
@@ -5,15 +5,22 @@ import MenuItem from "@mui/material/MenuItem";
 import Fade from "@mui/material/Fade";
 import CircleIcon from "@mui/icons-material/Circle";
 
-interface FadeMenuProps {
-  id: string; // ボタンごとの一意のIDを設定する
+interface ShiftButtonProps {
+  id: string; // 各ボタンの一意なID
+  weekKey: number; // 週の識別キー
 }
 
-export default function FadeMenu({ id }: FadeMenuProps) {
+export default function ShiftButton({ id, weekKey }: ShiftButtonProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedValue, setSelectedValue] = React.useState(
-    () => localStorage.getItem(`selectedValue-${id}`) || "＋" // 各ボタンに固有のキーを使用？？
+    () => localStorage.getItem(`selectedValue-${id}`) || "＋"
   );
+
+  React.useEffect(() => {
+    // 週が変わったら localStorage から値を再取得
+    const storedValue = localStorage.getItem(`selectedValue-${id}`);
+    setSelectedValue(storedValue || "＋");
+  }, [weekKey, id]);
 
   const open = Boolean(anchorEl);
 
@@ -27,11 +34,10 @@ export default function FadeMenu({ id }: FadeMenuProps) {
 
   const handleMenuItemClick = (value: string) => {
     setSelectedValue(value); // 選択された値を状態に設定
-    localStorage.setItem(`selectedValue-${id}`, value); // 各ボタンに固有のキーでローカルストレージに保存
+    localStorage.setItem(`selectedValue-${id}`, value);
     handleClose(); // メニューを閉じる
   };
 
-  // ボタンの背景色を選択値に応じて設定
   const getButtonColor = () => {
     switch (selectedValue) {
       case "朝":

--- a/cocofill-client/src/app/components/test/TestTableMUI.tsx
+++ b/cocofill-client/src/app/components/test/TestTableMUI.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
-import { calcWeek, hour } from "../../const/test/utils";
+import { calcWeek } from "../../const/test/utils";
 import { Dayjs } from "dayjs";
 
 // 型指定

--- a/cocofill-client/src/app/components/test/TestTableMUI.tsx
+++ b/cocofill-client/src/app/components/test/TestTableMUI.tsx
@@ -95,9 +95,11 @@ const rows: RowData[] = [
 export default function TestTableMUI() {
   const [week, setWeek] = useState<Dayjs[]>(calcWeek()); //calcWeekは現在の週のデータを返している
 
+  const [weekKey, setWeekKey] = useState(0); // 週が変わる度にbuttonの表示をリセットするために追加
+
   // カラムを動的に生成
   const columns: Column[] = [
-    { id: "name", label: "", date: "", align: "center" as const, minWidth: 40 },
+    { id: "name", label: "", date: "", align: "center" as const, minWidth: 40 }, // as constにしないとエラーが出る
     ...week.map((day, index) => ({
       id: `day-${index}`,
       label: day.format("dd"), // 曜日表示
@@ -121,12 +123,20 @@ export default function TestTableMUI() {
         ? week[0].add(7, "day").format("YYYY-MM-DD")
         : week[0].subtract(7, "day").format("YYYY-MM-DD");
     setWeek(calcWeek(startDay)); //weekにstartDayの状態(日付)をセット(更新)
+    setWeekKey((prevKey) => prevKey + 1); // 週が変更されるたびに weekKey を更新
   };
 
   return (
     <>
       <Stack direction="row" padding={1}>
-        <Button onClick={() => setWeek(calcWeek())}>今日</Button>
+        <Button
+          onClick={() => {
+            setWeek(calcWeek());
+            setWeekKey((prevKey) => prevKey + 1); // 週をリセットする時も weekKey を更新
+          }}
+        >
+          今日
+        </Button>
         {/* ボタンが押されたらcalcWeek(現在の週のデータ返す)をweekにセット */}
         <IconButton onClick={() => moveWeek("back")}>
           <ArrowBackIosNewIcon sx={{ width: 20 }} />
@@ -219,6 +229,7 @@ export default function TestTableMUI() {
                       >
                         <ShiftButton
                           id={`${row.name}-${week[idx].format("YYYY-MM-DD")}`}
+                          weekKey={weekKey} // 親から weekKey を渡す
                         />
                       </TableCell>
                     ))}

--- a/cocofill-client/src/app/components/test/TestTableMUI.tsx
+++ b/cocofill-client/src/app/components/test/TestTableMUI.tsx
@@ -17,6 +17,7 @@ import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { calcWeek } from "../../const/test/utils";
 import { Dayjs } from "dayjs";
+import ShiftButton from "../ShiftButton";
 
 // 型指定
 interface Column {
@@ -75,7 +76,7 @@ const rows: RowData[] = [
   },
   {
     name: "今井",
-    shifts: ["朝", "朝", "朝", "朝", "朝", "朝", "朝"],
+    shifts: ["朝", "朝", "朝", "朝", "朝", "休", "休"],
   },
   {
     name: "佐々木",
@@ -135,7 +136,7 @@ export default function TestTableMUI() {
         </IconButton>
       </Stack>
       <Paper sx={{ width: "100%" }}>
-        <TableContainer sx={{ maxHeight: 700 }}>
+        <TableContainer sx={{ maxHeight: 650 }}>
           <Table stickyHeader aria-label="sticky table">
             <TableHead>
               <TableRow>
@@ -216,9 +217,9 @@ export default function TestTableMUI() {
                         align="center"
                         sx={{ borderRight: "1px solid #ddd" }}
                       >
-                        <Button variant="outlined" size="small">
-                          ＋
-                        </Button>
+                        <ShiftButton
+                          id={`${row.name}-${week[idx].format("YYYY-MM-DD")}`}
+                        />
                       </TableCell>
                     ))}
                   </TableRow>


### PR DESCRIPTION
# やったこと
- ボタンを押すと「朝・中・遅・休」を選択できる
- その値を選択したらボタンの値や色が変わる
- 一旦localStrageに保存して、リロード時に値が初期化されるのを防いだ
- ボタンで選択した値を一意のid (名前-YYYY-MM-DD) で持たせることができた
- 次の週や前の週に行ったときにもボタンを初期状態にした
- localStrageに保存されているデータからボタンを変更することができた

# やっていないこと
- ~~次の週や前の週に行ったときにボタンが初期状態にならない~~
- ~~localStrageからデータを取得してボタンを表示していない~~

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/110aff46-fff7-4001-b4f2-d1b20f98c0c1">
<img width="1470" alt="スクリーンショット 2024-11-03 21 20 57" src="https://github.com/user-attachments/assets/77c74b9a-fae1-4b7b-a684-80a843ef6aa3">


https://github.com/user-attachments/assets/436b0c8b-27b5-4ec6-be57-7361ee298612


