### PR TITLE
提出されたシフトに対して選択しているシフトが適切かどうか判断する機能を追加(まだできていないので一旦マージ)

### DIFF
--- a/cocofill-client/app/_components/CompareShiftRequest.tsx
+++ b/cocofill-client/app/_components/CompareShiftRequest.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface CompareShiftRequestProps {
+  shiftValue: string;
+  selectedValue: string;
+}
+
+const CompareShiftRequest: React.FC<CompareShiftRequestProps> = ({
+  shiftValue,
+  selectedValue,
+}) => {
+  // シフト希望と選択値を比較
+  const displayValue = shiftValue === selectedValue ? "◎" : "※";
+
+  return <div>{displayValue}</div>;
+};
+
+export default CompareShiftRequest;

--- a/cocofill-client/app/_components/CompareShiftRequest.tsx
+++ b/cocofill-client/app/_components/CompareShiftRequest.tsx
@@ -1,18 +1,18 @@
-import React from "react";
+// import React from "react";
 
-interface CompareShiftRequestProps {
-  shiftValue: string;
-  selectedValue: string;
-}
+// interface CompareShiftRequestProps {
+//   shiftValue: string;
+//   selectedValue: string;
+// }
 
-const CompareShiftRequest: React.FC<CompareShiftRequestProps> = ({
-  shiftValue,
-  selectedValue,
-}) => {
-  // シフト希望と選択値を比較
-  const displayValue = shiftValue === selectedValue ? "◎" : "※";
+// const CompareShiftRequest: React.FC<CompareShiftRequestProps> = ({
+//   shiftValue,
+//   selectedValue,
+// }) => {
+//   // シフト希望と選択値を比較
+//   const displayValue = shiftValue === selectedValue ? "◎" : "※";
 
-  return <div>{displayValue}</div>;
-};
+//   return <div>{displayValue}</div>;
+// };
 
-export default CompareShiftRequest;
+// export default CompareShiftRequest;

--- a/cocofill-client/app/_components/CreateShiftView.tsx
+++ b/cocofill-client/app/_components/CreateShiftView.tsx
@@ -13,7 +13,6 @@ import {
   IconButton,
   Stack,
   Box,
-  Typography,
 } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";

--- a/cocofill-client/app/_components/ShiftCellColor.tsx
+++ b/cocofill-client/app/_components/ShiftCellColor.tsx
@@ -1,32 +1,32 @@
-import React from "react";
-import { TableCell } from "@mui/material";
+// import React from "react";
+// import { TableCell } from "@mui/material";
 
-interface ShiftCellColorProps {
-  shiftValue: string;
-  selectedValue: string;
-  children: React.ReactNode;
-}
+// interface ShiftCellColorProps {
+//   shiftValue: string;
+//   selectedValue: string;
+//   children: React.ReactNode;
+// }
 
-const ShiftCellColor: React.FC<ShiftCellColorProps> = ({
-  shiftValue,
-  selectedValue,
-  children,
-}) => {
-  console.log("ShiftCellColor:", { shiftValue, selectedValue }); // デバッグ用
-  // 条件に基づいて背景色を変更
-  const backgroundColor =
-    shiftValue === "朝" && (selectedValue === "中" || selectedValue === "遅")
-      ? "rgba(255, 0, 0, 0.5)" // 薄い赤色
-      : "transparent"; // デフォルトの背景色
+// const ShiftCellColor: React.FC<ShiftCellColorProps> = ({
+//   shiftValue,
+//   selectedValue,
+//   children,
+// }) => {
+//   console.log("ShiftCellColor:", { shiftValue, selectedValue }); // デバッグ用
+//   // 条件に基づいて背景色を変更
+//   const backgroundColor =
+//     shiftValue === "朝" && (selectedValue === "中" || selectedValue === "遅")
+//       ? "rgba(255, 0, 0, 0.5)" // 薄い赤色
+//       : "transparent"; // デフォルトの背景色
 
-  return (
-    <TableCell
-      align="center"
-      sx={{ backgroundColor, borderRight: "1px solid #ddd" }}
-    >
-      {children}
-    </TableCell>
-  );
-};
+//   return (
+//     <TableCell
+//       align="center"
+//       sx={{ backgroundColor, borderRight: "1px solid #ddd" }}
+//     >
+//       {children}
+//     </TableCell>
+//   );
+// };
 
-export default ShiftCellColor;
+// export default ShiftCellColor;

--- a/cocofill-client/app/_components/ShiftCellColor.tsx
+++ b/cocofill-client/app/_components/ShiftCellColor.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { TableCell } from "@mui/material";
+
+interface ShiftCellColorProps {
+  shiftValue: string;
+  selectedValue: string;
+  children: React.ReactNode;
+}
+
+const ShiftCellColor: React.FC<ShiftCellColorProps> = ({
+  shiftValue,
+  selectedValue,
+  children,
+}) => {
+  console.log("ShiftCellColor:", { shiftValue, selectedValue }); // デバッグ用
+  // 条件に基づいて背景色を変更
+  const backgroundColor =
+    shiftValue === "朝" && (selectedValue === "中" || selectedValue === "遅")
+      ? "rgba(255, 0, 0, 0.5)" // 薄い赤色
+      : "transparent"; // デフォルトの背景色
+
+  return (
+    <TableCell
+      align="center"
+      sx={{ backgroundColor, borderRight: "1px solid #ddd" }}
+    >
+      {children}
+    </TableCell>
+  );
+};
+
+export default ShiftCellColor;


### PR DESCRIPTION
1. 提出されたシフト(可)などの横に「※や◎」を表示する
2. シフト作成ボタン(+)の横に「※や◎」を表示する
3. セルの背景の色を変える

上記3つのどれかで、作成したシフトが適切かどうか判断する機能をつけたいと考えている。
1と2は実装可能だが、デザインがかなり崩れる(最悪気にしない)。[CompareShiftReques.tsx]
3はセルの背景色がうまく変わらなかった(また後ほど実装)。[ShiftCellColor.tsx]